### PR TITLE
Nissix plugin update-package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
   },
   "homepage": "https://github.com/deanshub/stickerify#readme",
   "dependencies": {
-    "config": "^3.3.0",
-    "fs-extra": "^8.1.0",
+    "config": "^3.3.6",
+    "fs-extra": "^10.0.0",
     "node-telegram-bot-api": "^0.40.0",
     "resize-img": "^2.0.0"
   },
   "devDependencies": {
     "@types/config": "^0.0.36",
-    "@types/fs-extra": "^8.1.0",
+    "@types/fs-extra": "^9.0.13",
     "@types/node": "^13.9.0",
     "@types/node-telegram-bot-api": "^0.40.2",
     "@types/resize-img": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -264,10 +264,10 @@
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/config/-/config-0.0.36.tgz#bf53ca640f3a1a6a2072a9f33e02a44def07a40b"
   integrity sha1-v1PKZA86GmogcqnzPgKkTe8HpAs=
 
-"@types/fs-extra@^8.1.0":
-  version "8.1.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/fs-extra/-/fs-extra-8.1.0.tgz#1114834b53c3914806cd03b3304b37b3bd221a4d"
-  integrity sha1-ERSDS1PDkUgGzQOzMEs3s70iGk0=
+"@types/fs-extra@^9.0.13":
+  version "9.0.13"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
+  integrity sha1-dZT7rgT+fxkYzos9IT90/0SsH0U=
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
Nissix plugin update-package

#Error Log:
(node:373) UnhandledPromiseRejectionWarning: Error: Command failed with exit code 1: yarn add fs-extra@latest
error An unexpected error occurred: "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/node-telegram-bot-api/-/node-telegram-bot-api-0.40.0.tgz: ENOENT: no such file or directory, open '/home/deployer/.cache/yarn/v6/npm-node-telegram-bot-api-0.40.0-7e6acf631e868b8000025808daf566181c7673d5-integrity/node_modules/node-telegram-bot-api/.yarn-tarball.tgz'".
yarn add v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
info If you think this is a bug, please open a bug report with the information provided in "/tmp/3618cae0e170fc7a2cd11f4eadbfc16e/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
    at makeError (/app/node_modules/execa/lib/error.js:59:11)
    at handlePromise (/app/node_modules/execa/index.js:114:26)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:373) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:373) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

